### PR TITLE
fix backward compatibility for old datasets

### DIFF
--- a/public/utils/command-utils.js
+++ b/public/utils/command-utils.js
@@ -124,8 +124,11 @@ function generateUrlForAdvancedRuleWithSimpleParam(
   // find string at above position in typedCommand
   const paramValue = typedCommand.substr(commandParamPosition).trim();
   // replace url param with found string
-  return rule.url.replace(
-    paramRegex,
-    get_closest_match(paramValue, dataset.values, (record) => record)
-  );
+  const toReplaceValueFromDataset =
+    typeof dataset.values[0] === 'string'
+      ? get_closest_match(paramValue, dataset.values, (record) => record)
+      : get_closest_match(paramValue, dataset.values, (record) => record.name)
+          .name;
+
+  return rule.url.replace(paramRegex, toReplaceValueFromDataset);
 }

--- a/src/components/DatasetsTab/AddModal.js
+++ b/src/components/DatasetsTab/AddModal.js
@@ -65,7 +65,7 @@ export function AddModal({ show, onSuccess, onClose }) {
             <Form.Label>JSON</Form.Label>
             <Form.Control
               as={'textarea'}
-              placeholder='["abc", "def", ...]'
+              placeholder='["value1", "value2", ...] or [{"key1": "value1", "key2": "value2"}, ...]'
               style={{ height: '300px' }}
               onChange={(e) => {
                 try {


### PR DESCRIPTION
Old datasets only took list of strings as such `["str1", "str2", ...]` which was internally stored as `[{"name": "str1"}, {"name": "str2"}]`
To maintain backward compatibility make sure to also resolve for those datasets.